### PR TITLE
Add error handling for UTP version of 'EADDRINUSE'

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class Hyperdiscovery extends EventEmitter {
       debug('swarm:listening', { port: this.port })
     })
     this._swarm.on('error', (err) => {
-      if (err && err.code !== 'EADDRINUSE') return this.emit('error', err)
+      if (err && err.code !== 'EADDRINUSE' && err.message !== 'Could not bind') return this.emit('error', err)
       const port = this._portAlts.shift()
       debug(`Port ${this._port} in use. Trying ${port}.`)
       this.listen(port)


### PR DESCRIPTION
@RangerMauve and I figured out the problem in #35. The UTP socket was trying to bind to a port that was in use, but hyperdiscovery wasn't handling the Error that utp-native thows. (re) closes #35